### PR TITLE
Added `refundTxHashes` field to docs

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -41,6 +41,7 @@ This is useful for sending multiple transactions that depend on each other.
 
         revertingTxHashes // Array[String], A list of tx hashes that are allowed to revert.
         droppingTxHashes  // Array[String], A list of tx hashes that can be removed from the bundle if it's deemed useful (but not revert).
+        refundTxHashes    // Array[String], A list of tx hashes (max 1) that should be considered for MEV refunds. If empty, defaults to the last transaction in the bundle.
 
         minTimestamp      // Number, The minimum timestamp for which this bundle is valid, in seconds since the unix epoch.
         maxTimestamp      // Number, The maximum timestamp for which this bundle is valid, in seconds since the unix epoch.
@@ -62,13 +63,18 @@ This is useful for sending multiple transactions that depend on each other.
 - **Replacing bundles**: Send another bundle with the same `replacementUuid` , and it will override any previous one.
 - **Cancelling bundles**: Send another bundle with the same `replacementUuid` and an empty list of transactions.
 
-**Refunds:**
+**MEV Refunds:**
 
-- Refunds are based on the last transaction in the bundle.
+- MEV Refunds are based on the last transaction in the bundle.
+- `refundTxHashes` field
+  - (Optional) Specifies which transactions in the bundle should be considered for MEV refund calculations. 
+  - Currently limited to maximum 1 transaction hash.
+  - If empty or not specified, defaults to the last transaction in the bundle.
+  - This determines which part of the bundle contains the backrun transactions that tip the coinbase, and the refundable value is calculated from the priority fees of these specified transactions.
 - `refundPercent` field
   - (Optional) An integer between 1-99 which defines how much of the total priority fee + coinbase payment you want to be refunded for.
   - Example: If a bundle pays 0.2 ETH of priority fee plus 1 ETH to coinbase, a refundPercent set to 50 will result in a transaction being appended after the bundle, paying 0.59 ETH back to the EOA. This is assuming the payout tx will cost beaver 0.01 ETH in fees, which are deduced from the 0.6 ETH payout.
-- See also [Refunds](./refunds.mdx) for more details.
+- For fee refunds see [Refunds](./refunds.mdx).
 
 ### Response <!-- omit in toc -->
 


### PR DESCRIPTION
Add refunTxHashes to docs. Should it be camelCase?
I also specified which ones are mev-refunds and which ones are fee refunds