### PR TITLE
Update documentation to use attested-tls-proxy rather than cvm-reverse-proxy for getting TLS certificates

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -206,18 +206,17 @@ You can find more details in the [Constellation docs](https://docs.edgeless.syst
 >
 > The protocol can be used by clients to verify a server certificate, by a server to verify a client certificate, or for mutual verification (mutual aTLS).
 
-In BuilderNet, [github.com/flashbots/cvm-reverse-proxy](https://github.com/flashbots/cvm-reverse-proxy) is responsible for attested TLS (aTLS) communication, both towards users as well as within the network.
-You can use the [`attested-get`](https://github.com/flashbots/cvm-reverse-proxy/blob/main/cmd/attested-get/main.go) tool to receive the builder certificate over an attested channel:
+In BuilderNet,
+[github.com/flashbots/attested-tls-proxy](https://github.com/flashbots/attested-tls-proxy) is responsible for attested TLS communication, both towards users as well as within the network.
+You can use the [`attested-tls-proxy get-tls-cert`](https://github.com/flashbots/attested-tls-proxy) command to receive the builder certificate over an attested channel:
 
 ```bash
-# Install attested-get
-go install github.com/flashbots/cvm-reverse-proxy/cmd/attested-get
+cargo install --git https://github.com/flashbots/attested-tls-proxy attested-tls-proxy
+# optionally add --tag <version number of latest release>
 
-# Get the builder certificate over an attested channel
-attested-get \
-    --addr=https://rpc.buildernet.org:7936/cert \
-    --expected-measurements=https://measurements.buildernet.org \
-    --out-response=builder-cert.pem
+attested-tls-proxy get-tls-cert \
+    --measurements-file https://measurements.buildernet.org \
+    rpc.buildernet.org:7936/cert > builder-cert.pem
 ```
 
 See also "[Orderflow encryption and attestation](encryption-attestations)" for more details.
@@ -470,5 +469,4 @@ The response contains three fields:
 - `indexedUpTo`: the highest block number for which delayed refunds have been processed
 - `pending`: the total amount of fee refunds that have been earned but not yet received by the recipient
 - `received`: the total amount of fee refunds that have been received by the recipient
-
 

--- a/docs/encryption-attestations.mdx
+++ b/docs/encryption-attestations.mdx
@@ -39,37 +39,42 @@ Client requests require the server to own the private key for this particular TL
 ## TEE attestation of the certificate
 
 TEE attestation allows you to verify that a given TLS certificate belongs to a particular VM image (with specific codebase and configuration).
-On every builder node, an API on port 7936 serves the local certificate over an aTLS attested channel.
+On every builder node, an API on port 7936 serves the local certificate over an attested-TLS channel.
 
 :::info
 
-Read more about aTLS in the [Constellation documentation](https://github.com/edgelesssys/constellation/blob/main/internal/atls/README.md).
+Read more about attested-tls in the [documentation](https://github.com/flashbots/attested-tls-proxy/tree/main/attested-tls/README.md).
 
 :::
 
 
-As part of the aTLS handshake, the client (i.e. user) can verify that the server runs inside a TEE instance with specific measurements
+As part of the attested-TLS handshake, the client (i.e. user) can verify that the server runs inside a TEE instance with specific measurements
 (i.e. specific codebase and configuration).
 
-You can use [this tool](https://github.com/flashbots/cvm-reverse-proxy/blob/main/cmd/attested-get/main.go) to get the certificate with TEE attestation:
+You can use [this tool](https://github.com/flashbots/attested-tls-proxy) to get the certificate with TEE attestation:
+
+Installing with `cargo`:
 
 ```bash
-# Install attested-get
-go install github.com/flashbots/cvm-reverse-proxy/cmd/attested-get
+cargo install --git https://github.com/flashbots/attested-tls-proxy attested-tls-proxy
+# optionally add --tag <version number of latest release>
+```
 
-attested-get \
-    --addr=https://rpc.buildernet.org:7936/cert \
-    --out-measurements=measurements.json \
-    --out-response=builder-cert.pem
+Alternatively see the [releases page](https://github.com/flashbots/attested-tls-proxy/releases) to install from pre-built x86 binary or debian package.
+
+```
+attested-tls-proxy get-tls-cert \
+    --allowed-remote-attestaton-type tdx \
+    --out-measurements measurements.json \
+    rpc.buildernet.org:7936/cert > builder-cert.pem
 ```
 
 Here's an example command for an attested request to the Flashbots BuilderNet node, matching expected measurements from https://measurements.buildernet.org:
 
 ```
-attested-get \
-    --addr=https://rpc.buildernet.org:7936/cert \
-    --expected-measurements=https://measurements.buildernet.org \
-    --out-response=builder-cert.pem
+attested-tls-proxy get-tls-cert \
+    --measurements-file https://measurements.buildernet.org \
+    rpc.buildernet.org:7936/cert > builder-cert.pem
 ```
 
 You can then use the `builder-cert.pem` file to verify the attested TLS certificate in your future requests to BuilderNet.

--- a/docs/network-ports.mdx
+++ b/docs/network-ports.mdx
@@ -26,7 +26,7 @@ Ports open for connections from outside the TDX instance.
 | ---- | ---------------- | --------------------------------------------------------------------------- | ----------------------------------------------------- |
 | 80   | TCP (HTTP)       | HAProxy                                                                     | Permanent redirect to HTTPS                           |
 | 443  | TCP (HTTPS)      | HAProxy for [orderflow-proxy](https://github.com/flashbots/orderflow-proxy) | Orderflow from operator, users, wallets, etc.         |
-| 7936 | TCP (HTTPS/aTLS) | [cvm-proxy](https://github.com/flashbots/cvm-reverse-proxy)                 | aTLS attested channel to serve local TLS certificate. |
+| 7936 | TCP (HTTPS/aTLS) | [attested-tls-proxy](https://github.com/flashbots/attested-tls-proxy)       | Attested TLS channel to serve local TLS certificate.  |
 
 **Selective access**
 
@@ -43,10 +43,10 @@ Ports open to requests from inside the TDX instance only.
 
 | Port  | Protocol   | Service                                                                      | Use                                                                                                                                                                                            |
 | ----- | ---------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 14727 | TCP (HTTP) | HAProxy                                                                      | Serving `GET /cert` REST API (which is used by cvm-proxy on port 7936).                                                                                                                        |
+| 14727 | TCP (HTTP) | HAProxy                                                                      | Serving `GET /cert` REST API (which is used by attested-tls-proxy on port 7936).                                                                                                               |
 | 5542  | TCP (HTTP) | [orderflow-proxy](https://github.com/flashbots/orderflow-proxy)              | System orderflow, via HAProxy on port 5544.                                                                                                                                                    |
 | 5543  | TCP (HTTP) | [orderflow-proxy](https://github.com/flashbots/orderflow-proxy)              | User orderflow, via HAProxy on port 443.                                                                                                                                                       |
-| 7937  | TCP (HTTP) | [cvm-proxy](https://github.com/flashbots/cvm-reverse-proxy)                  | Proxy for requests to Flashbots infra (BuilderHub) using client-aTLS-attestation. Used to retrieve secrets and configuration, a list of peers, and for services to register their public keys. |
+| 7937  | TCP (HTTP) | [attested-tls-proxy](https://github.com/flashbots/attested-tls-proxy)        | Proxy for requests to Flashbots infra (BuilderHub) using client-aTLS-attestation. Used to retrieve secrets and configuration, a list of peers, and for services to register their public keys. |
 | 8645  | TCP        | [rbuilder](https://github.com/flashbots/rbuilder)                            | JSON-RPC API (requests are sent from orderflow-proxy).                                                                                                                                         |
 | 6069  | TCP        | [rbuilder](https://github.com/flashbots/rbuilder)                            | Prometheus telemetry.                                                                                                                                                                          |
 | 6070  | TCP        | [rbuilder](https://github.com/flashbots/rbuilder)                            | Redacted telemetry and health check                                                                                                                                                            |
@@ -71,6 +71,6 @@ On the firewall, these ports should be opened up for either private or public ac
 | 30303 | Reth                          | **Public**                     | Execution network peering                                           |
 | 80    | HAProxy                       | **Public**                     | Redirect to HTTPS                                                   |
 | 443   | Orderflow Proxy (via HAProxy) | Operator, optionally for users | Receive orderflow from operator, users, wallets.                    |
-| 7936  | cvm-proxy                     | Operator, optionally for users | Serve the local TLS certificate through an attested channel (aTLS). |
+| 7936  | attested-tls-proxy            | Operator, optionally for users | Serve the local TLS certificate through an attested channel (aTLS). |
 | 3535  | Operator Api                  | Operator                       | Admin interface                                                     |
 | 14192 | SSH                           | Operator                       | SSH access to the instance                                          |

--- a/docs/open-source.mdx
+++ b/docs/open-source.mdx
@@ -15,7 +15,7 @@ BuilderNet is running open source software and infrastructure.
 | [github.com/sigp/lighthouse](https://github.com/sigp/lighthouse)                                           | CL client                                                        |
 | [github.com/paradigmxyz/reth/](https://github.com/paradigmxyz/reth/)                                       | EL client                                                        |
 | [github.com/flashbots/system-api](https://github.com/flashbots/system-api)                                 | Interface between operators and services inside the TDX instance |
-| [github.com/flashbots/cvm-reverse-proxy](https://github.com/flashbots/cvm-reverse-proxy)                   | For verifying TDX measurements using attestations                |
+| [github.com/flashbots/attested-tls-proxy](https://github.com/flashbots/attestd-tls-proxy)                  | For verifying TDX measurements using attestations                |
 | [github.com/flashbots/buildernet-orderflow-proxy](https://github.com/flashbots/buildernet-orderflow-proxy) | Receiving and multiplexing orderflow                             |
 
 ---

--- a/docs/os-services-builds.mdx
+++ b/docs/os-services-builds.mdx
@@ -23,7 +23,7 @@ These are the main services running inside an instance:
 | [github.com/sigp/lighthouse](https://github.com/sigp/lighthouse)                                           | CL client                                                        |
 | [github.com/paradigmxyz/reth/](https://github.com/paradigmxyz/reth/)                                       | EL client                                                        |
 | [github.com/flashbots/system-api](https://github.com/flashbots/system-api)                                 | Interface between operators and services inside the TDX instance |
-| [github.com/flashbots/cvm-reverse-proxy](https://github.com/flashbots/cvm-reverse-proxy)                   | For verifying TDX measurements using attestations                |
+| [github.com/flashbots/attested-tls-proxy](https://github.com/flashbots/attested-tls-proxy)                 | For verifying TDX measurements using attestations                |
 | [github.com/flashbots/buildernet-orderflow-proxy](https://github.com/flashbots/buildernet-orderflow-proxy) | Receiving and multiplexing orderflow                             |
 
 Additional software that runs inside the TDX instance includes cron, time synchronization, utilities for mounting the encrypted disk and a Reth database downloader (for fast chain syncs).

--- a/docs/send-orderflow.mdx
+++ b/docs/send-orderflow.mdx
@@ -63,7 +63,6 @@ curl https://rpc.buildernet.org \
     }'
 ```
 
-
 See [this example Golang code](https://github.com/flashbots/go-utils/blob/main/examples/send-multioperator-orderflow/main.go) for sending a transaction with a signed request and a pinned server certificate.
 
 You can use the `--cacert builder-cert.pem` option with curl to verify the attested TLS certificate of the BuilderNet node. You can get the public certificate (`builder-cert.pem`) over an attested channel (see the next section "[TEE proof validation](#tee-attestation)") or through an unattested `curl` request:
@@ -80,19 +79,24 @@ Verify that a builder node runs the correct code and configuration inside a spec
 
 It works by making a HTTPS request through an attested connection. During the TLS handshake, the server proves that it's running inside a TEE with specific measurements and responds with a TLS certificate for future use. Based on the verifiable code and configuration, this provides assurances that this certificate belongs to a specific VM image with specific measurements.
 
-You can use our open-source [`attested-get` tool](https://github.com/flashbots/cvm-reverse-proxy/blob/main/cmd/attested-get/main.go) to receive the certificate **over an attested channel** (after verifying the TEE proof) and save it as `builder-cert.pem`:
+You can use our open-source [`attested-tls-proxy` tool](https://github.com/flashbots/attested-tls-proxy) to receive the certificate **over an attested channel** (after verifying the TEE proof) and save it as `builder-cert.pem`:
+
+Installing with `cargo`:
 
 ```bash
-# Install attested-get tool
-go install github.com/flashbots/cvm-reverse-proxy/cmd/attested-get
-
-# Get the builder certificate over an attested channel
-attested-get \
-    --addr=https://rpc.buildernet.org:7936/cert \
-    --expected-measurements=https://measurements.buildernet.org \
-    --out-response=builder-cert.pem
+cargo install --git https://github.com/flashbots/attested-tls-proxy attested-tls-proxy
+# optionally add --tag <version number of latest release>
 ```
 
+Alternatively see the [releases page](https://github.com/flashbots/attested-tls-proxy/releases) to install from pre-built x86 binary or debian package.
+
+```bash
+# Get the builder certificate over an attested channel
+attested-tls-proxy get-tls-cert \
+    --expected-measurements=https://measurements.buildernet.org \
+    --out-measurements measurements.json \
+    rpc.buildernet.org:7936 > builder-cert.pem
+```
 
 <details>
   <summary>Example output</summary>

--- a/docs/send-orderflow.mdx
+++ b/docs/send-orderflow.mdx
@@ -93,6 +93,7 @@ Alternatively see the [releases page](https://github.com/flashbots/attested-tls-
 ```bash
 # Get the builder certificate over an attested channel
 attested-tls-proxy get-tls-cert \
+    --log-debug \
     --expected-measurements=https://measurements.buildernet.org \
     --out-measurements measurements.json \
     rpc.buildernet.org:7936 > builder-cert.pem
@@ -102,51 +103,58 @@ attested-tls-proxy get-tls-cert \
   <summary>Example output</summary>
 
 ```bash
-time=2025-04-24T11:12:19.747+01:00 level=INFO msg="Loading expected measurements from https://measurements.buildernet.org ..." service=attested-get version=dev
-time=2025-04-24T11:12:20.186+01:00 level=INFO msg="Measurements loaded" service=attested-get version=dev measurements=4
-time=2025-04-24T11:12:20.186+01:00 level=INFO msg="Executing attested GET request to https://rpc.buildernet.org:7936/cert ..." service=attested-get version=dev
-time=2025-04-24T11:12:20.786+01:00 level=INFO msg="Validating attestation document" service=attested-get version=dev
-time=2025-04-24T11:12:21.940+01:00 level=INFO msg="Successfully validated attestation document" service=attested-get version=dev
-time=2025-04-24T11:12:22.051+01:00 level=INFO msg="Measurements for azure-tdx with 24 entries:" service=attested-get version=dev
-{
-    "0": "2ade8023eeec241d83eff996830fd33b6b26811a79e8e809def01296337abced",
-    "1": "3d458cfe55cc03ea1f443f1562beec8df51c75e14a9fcf9a7234a13f198e7969",
-    "10": "0000000000000000000000000000000000000000000000000000000000000000",
-    "11": "3aede0e78b33f4197175b73468be54f168a46719c063b7c4f27c10984e614b38",
-    "12": "0000000000000000000000000000000000000000000000000000000000000000",
-    "13": "0000000000000000000000000000000000000000000000000000000000000000",
-    "14": "0000000000000000000000000000000000000000000000000000000000000000",
-    "15": "0000000000000000000000000000000000000000000000000000000000000000",
-    "16": "0000000000000000000000000000000000000000000000000000000000000000",
-    "17": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-    "18": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-    "19": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-    "2": "3d458cfe55cc03ea1f443f1562beec8df51c75e14a9fcf9a7234a13f198e7969",
-    "20": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-    "21": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-    "22": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-    "23": "0000000000000000000000000000000000000000000000000000000000000000",
-    "3": "3d458cfe55cc03ea1f443f1562beec8df51c75e14a9fcf9a7234a13f198e7969",
-    "4": "966f0aa4b6f6952e601712cfe78f71a6ae61467a425a92d0800c754e98933d78",
-    "5": "18b53ae9ecb6aca7d765eae8e4324ecb61691822deb2bd6d318b76b6835ae4f0",
-    "6": "737a9771c3575e3202b8dc69e4881de4b666253cfa92a5dbac6d99fd7e81c8c2",
-    "7": "124daf47b4d67179a77dc3c1bcca198ae1ee1d094a2a879974842e44ab98bb06",
-    "8": "0000000000000000000000000000000000000000000000000000000000000000",
-    "9": "af03ec5b7f02f5b9779f04bc837b8cbbf85d5b0386d5f387d8b99e8f0d9a1fa4"
-}
-time=2025-04-24T11:12:22.051+01:00 level=INFO msg="Measurements match expected measurements ✅" service=attested-get version=dev matchedMeasurements=buildernet-v1.3.0-azure-tdx-d17a02695c1acc0800aff80e86efbe0e5919843184e6562d8d572894ab43d149.wic.vhd
-time=2025-04-24T11:12:22.051+01:00 level=INFO msg="Response body with 696 bytes:" service=attested-get version=dev
+2026-02-26T11:42:13.089235Z DEBUG attested_tls_proxy: [get-tls-cert] Connected to proxy server with measurements: Some(Dcap({MRTD: "a5844e88897b70c318bef929ef4dfd6c7304c52c4bc9c3f39132f0fdccecf3eb5bab70110ee42a12509a31c037288694", RTMR0: "01aff01b3e5d096424a6459d01edb74d33f5afc128a5dc8e6361c5b5787d0be699e321653c8f616a778a929593b66224", RTMR1: "fffc20aa213d96464a8c18ddc94315e19c4f86fd99c55e3c131e8170c44004ae212b8fce03c254ff07ad5edcb44cc2d9", RTMR2: "d89c46ca963123e4344716e101a6b22d0e40b24c748c704d94f875fb7b7c097f850fe4ac59c02cb2adf20e303eeca565", RTMR3: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}))
+    at src/lib.rs:81
+
 -----BEGIN CERTIFICATE-----
-MIIB1TCCAXugAwIBAgIRAJpsLIpuWcMaYpyLRyfzzu0wCgYIKoZIzj0EAwIwDzEN
-MAsGA1UEChMEQWNtZTAeFw0yNTA0MjMxMDAzMDNaFw0yNjA0MjMxMDAzMDNaMA8x
-DTALBgNVBAoTBEFjbWUwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASA4Uu/+Pgc
-AAmWJGnMIpmaGmtFnRN+CBJhwbo7TCipr8SteJvPNVxST2bPEyfCBFshqIOPOKmb
-fAMdHhfiDTGoo4G3MIG0MA4GA1UdDwEB/wQEAwIChDATBgNVHSUEDDAKBggrBgEF
-BQcDATAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQny7C1W6ZyOLHBj65XmNlW
-uJYJgjBdBgNVHREEVjBUgglsb2NhbGhvc3SCO2J1aWxkZXJuZXQtZmxhc2hib3Rz
-LWF6dXJlLWVhc3R1czItMDUuYnVpbGRlci5mbGFzaGJvdHMubmV0hwR/AAABhwSs
-yxY0MAoGCCqGSM49BAMCA0gAMEUCIDU9SabP100dPVBCUoQJ7RkmH9hEbjinNgdF
-MREbwxknAiEA51ZRCYn/9UDvQA6DqCgNndwU1x2N2EvDtDAG79ZhVo0=
+MIID2DCCA1+gAwIBAgISBashRlGF7dX7v6wdLGnfLtnmMAoGCCqGSM49BAMDMDIx
+CzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQswCQYDVQQDEwJF
+NzAeFw0yNjAxMTIxODMyNDRaFw0yNjA0MTIxODMyNDNaMB0xGzAZBgNVBAMTEnJw
+Yy5idWlsZGVybmV0Lm9yZzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABIYPwIJ8
+8Z2KOrtyeFzmS9hQg6OfcARQ7PyRW2LknW0y6oj3Clbqp/sygEhaJGOyMPpJ1+AA
+j5WVH/46VzUukjOjggJoMIICZDAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYI
+KwYBBQUHAwEGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwHQYDVR0OBBYEFP+OAQT2
+YpDMzXnmriqtp9tLAAKbMB8GA1UdIwQYMBaAFK5IntyHHUSgb9qi5WB0BHjCnACA
+MDIGCCsGAQUFBwEBBCYwJDAiBggrBgEFBQcwAoYWaHR0cDovL2U3LmkubGVuY3Iu
+b3JnLzBlBgNVHREEXjBcghhkaXJlY3QtYXAuYnVpbGRlcm5ldC5vcmeCLGZsYXNo
+Ym90cy1nY3AtdG9reW8tMTAxLm5vZGVzLmJ1aWxkZXJuZXQub3JnghJycGMuYnVp
+bGRlcm5ldC5vcmcwEwYDVR0gBAwwCjAIBgZngQwBAgEwLgYDVR0fBCcwJTAjoCGg
+H4YdaHR0cDovL2U3LmMubGVuY3Iub3JnLzEwMy5jcmwwggEDBgorBgEEAdZ5AgQC
+BIH0BIHxAO8AdQBJnJtp3h187Pw23s2HZKa4W68Kh4AZ0VVS++nrKd34wwAAAZuz
+sOm5AAAEAwBGMEQCIGcYPmrbg1encTLTivyAdR0lnbnXOObNy+I/vvkZZSnBAiBu
+J7sAi0jsqgWr2ad5BHT/PcbY21NlPUakxlTOcEIS8wB2ABaDLavwqSUPD/A6pUX/
+yL/II9CHS/YEKSf45x8zE/X6AAABm7Ow6fMAAAQDAEcwRQIgS1REMQkH4aDn0Bqh
+PhB7/vn6WpAjiV9r7AnjrYKrUY4CIQCN6Dyz0XYyuZlQdYDxAGHLajFVu8l6Nx3F
+G1jSdSHlpjAKBggqhkjOPQQDAwNnADBkAjBS8c234+6btyeoiraJwtcRARSjPMvL
+2MniUYeUpjMZdIxJR7EA8F+REb1yqLdHdksCMCDmEv7pjmBmV9fIid2AVPzjfgEx
+eMdyfg1K/PcCGk/ax0xjtNTZTRq8mQE5h7m9dA==
+-----END CERTIFICATE-----
+
+-----BEGIN CERTIFICATE-----
+MIIEVzCCAj+gAwIBAgIRAKp18eYrjwoiCWbTi7/UuqEwDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMjQwMzEzMDAwMDAw
+WhcNMjcwMzEyMjM1OTU5WjAyMQswCQYDVQQGEwJVUzEWMBQGA1UEChMNTGV0J3Mg
+RW5jcnlwdDELMAkGA1UEAxMCRTcwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAARB6AST
+CFh/vjcwDMCgQer+VtqEkz7JANurZxLP+U9TCeioL6sp5Z8VRvRbYk4P1INBmbef
+QHJFHCxcSjKmwtvGBWpl/9ra8HW0QDsUaJW2qOJqceJ0ZVFT3hbUHifBM/2jgfgw
+gfUwDgYDVR0PAQH/BAQDAgGGMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcD
+ATASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBSuSJ7chx1EoG/aouVgdAR4
+wpwAgDAfBgNVHSMEGDAWgBR5tFnme7bl5AFzgAiIyBpY9umbbjAyBggrBgEFBQcB
+AQQmMCQwIgYIKwYBBQUHMAKGFmh0dHA6Ly94MS5pLmxlbmNyLm9yZy8wEwYDVR0g
+BAwwCjAIBgZngQwBAgEwJwYDVR0fBCAwHjAcoBqgGIYWaHR0cDovL3gxLmMubGVu
+Y3Iub3JnLzANBgkqhkiG9w0BAQsFAAOCAgEAjx66fDdLk5ywFn3CzA1w1qfylHUD
+aEf0QZpXcJseddJGSfbUUOvbNR9N/QQ16K1lXl4VFyhmGXDT5Kdfcr0RvIIVrNxF
+h4lqHtRRCP6RBRstqbZ2zURgqakn/Xip0iaQL0IdfHBZr396FgknniRYFckKORPG
+yM3QKnd66gtMst8I5nkRQlAg/Jb+Gc3egIvuGKWboE1G89NTsN9LTDD3PLj0dUMr
+OIuqVjLB8pEC6yk9enrlrqjXQgkLEYhXzq7dLafv5Vkig6Gl0nuuqjqfp0Q1bi1o
+yVNAlXe6aUXw92CcghC9bNsKEO1+M52YY5+ofIXlS/SEQbvVYYBLZ5yeiglV6t3S
+M6H+vTG0aP9YHzLn/KVOHzGQfXDP7qM5tkf+7diZe7o2fw6O7IvN6fsQXEQQj8TJ
+UXJxv2/uJhcuy/tSDgXwHM8Uk34WNbRT7zGTGkQRX0gsbjAea/jYAoWv0ZvQRwpq
+Pe79D/i7Cep8qWnA+7AE/3B3S/3dEEYmc0lpe1366A/6GEgk3ktr9PEoQrLChs6I
+tu3wnNLB2euC8IKGLQFpGtOO/2/hiAKjyajaBP25w1jF0Wl8Bbqne3uZ2q1GyPFJ
+YRmT7/OXpmOH/FVLtwS+8ng1cAmpCujPwteJZNcDG0sF2n/sc0+SQf49fdyUK0ty
++VUwFj9tmWxyR/M=
 -----END CERTIFICATE-----
 ```
 


### PR DESCRIPTION
This updates documentation to use `attested-tls-proxy`'s `get-tls-cert` command rather than `cvm-reverse-proxy` when directing users how to retrieve a TLS cert over an attested channel before using it to send orderflow.

This pairs with a PR to `attested-tls-proxy` with some minor changes to make the options more consistent with `attested-get. https://github.com/flashbots/attested-tls-proxy/pull/142

## Issue with Azure

Currently the documentation tells users to install the vanilla build with no azure support (since we made it opt-in).
For azure attestations, there are issues with installing on Macos, as well as a need for the `--override_azure_outdated_tcb` flag.

## TODO:
- [x] Update expected output
- [ ] Document azure issues