### PR TITLE
docs: add eth_sendBundle received timestamp

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -88,14 +88,16 @@ To determine how much the searcher paid the builder, we check the delta in the b
 
 #### Response <!-- omit in toc -->
 
-The response always contains the bundles unique hash which can then be used to query refunds:
+The response always contains the bundles unique hash which can then be used to query refunds.
+It also contains `receivedTimestampMs`, a Unix timestamp in milliseconds indicating when BuilderNet received the bundle. The value is a number and may include fractional milliseconds for microsecond precision.
 
 ```json
 {
     "id": 1,
     "jsonrpc": "2.0",
     "result": {
-      "bundleHash": "0x..."
+      "bundleHash": "0x...",
+      "receivedTimestampMs": 1718030000123.456
     }
 }
 ```
@@ -570,5 +572,4 @@ The response contains three fields:
 - `indexedUpTo`: the highest block number for which delayed refunds have been processed
 - `pending`: the total amount of fee refunds that have been earned but not yet received by the recipient
 - `received`: the total amount of fee refunds that have been received by the recipient
-
 


### PR DESCRIPTION
## Summary
- document the new receivedTimestampMs field in eth_sendBundle responses
- update the response example to show fractional millisecond precision